### PR TITLE
feat: Implement modern candidate profile UI and fix navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Candidate Management Portal</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1019,6 +1019,17 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.35",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.35.tgz",
@@ -1397,7 +1408,6 @@
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import CandidateRegister from "./components/candidates/CandidateRegister";
 import CandidateLogin from "./components/candidates/CandidateLogin";
 import CandidateProfile from "./components/candidates/CandidateProfile";
@@ -10,12 +10,20 @@ function App() {
   return (
     <Router>
       <Routes>
-        <Route path="/cadidate/register" element={<CandidateRegister />} />
+        {/* Default route - redirect to candidate login */}
+        <Route path="/" element={<Navigate to="/candidate/login" replace />} />
+        
+        {/* Candidate routes */}
+        <Route path="/candidate/register" element={<CandidateRegister />} />
         <Route path="/candidate/login" element={<CandidateLogin />} />
         <Route path="/candidate/profile" element={<CandidateProfile />} />
         
+        {/* Admin routes */}
         <Route path="/admin/login" element={<AdminLogin />} />
         <Route path="/admin/dashboard" element={<AdminDashboard />} />
+        
+        {/* Catch all route - redirect to candidate login */}
+        <Route path="*" element={<Navigate to="/candidate/login" replace />} />
       </Routes>
     </Router>
   );

--- a/src/components/candidates/CandidateLogin.jsx
+++ b/src/components/candidates/CandidateLogin.jsx
@@ -125,7 +125,7 @@ function CandidateLogin() {
                                     Don't have an account?
                                     <button
                                         type="button"
-                                        onClick={() => navigate("/cadidate/register")}
+                                        onClick={() => navigate("/candidate/register")}
                                         className="btn btn-link text-primary fw-semibold p-0 ms-1"
                                     >
                                         Register here

--- a/src/components/candidates/CandidateProfile.jsx
+++ b/src/components/candidates/CandidateProfile.jsx
@@ -183,338 +183,471 @@ function CandidateProfile() {
     const idProofInfo = getFileInfo(candidateData.idProof);
 
     return (
-        <div className="container mt-4">
-            {/* Header */}
-            <div className="row mb-4">
-                <div className="col-md-8">
-                    <h2 className="text-primary fw-bold">
-                        <i className="bi bi-person-circle me-2"></i>
-                        Candidate Profile
-                    </h2>
-                </div>
-                <div className="col-md-4 text-end">
-                    <button
-                        className="btn btn-outline-danger"
-                        onClick={handleLogout}
-                    >
-                        <i className="bi bi-box-arrow-right me-2"></i>
-                        Logout
-                    </button>
-                </div>
-            </div>
-
-            {/* Message Alert */}
-            {message && (
-                <div className={`alert ${message.includes("success") ? "alert-success" : message.includes("selected") ? "alert-info" : "alert-danger"} alert-dismissible fade show`}>
-                    {message}
-                    <button
-                        type="button"
-                        className="btn-close"
-                        onClick={() => setMessage("")}
-                    ></button>
-                </div>
-            )}
-
-            <div className="row">
-                {/* Profile Information Card */}
-                <div className="col-lg-8">
-                    <div className="card shadow">
-                        <div className="card-header bg-primary text-white d-flex justify-content-between align-items-center">
-                            <h5 className="mb-0">
-                                <i className="bi bi-info-circle me-2"></i>
-                                Profile Information
-                            </h5>
-                            {!isEditing ? (
-                                <button
-                                    className="btn btn-light btn-sm"
-                                    onClick={() => setIsEditing(true)}
-                                >
-                                    <i className="bi bi-pencil me-1"></i>
-                                    Edit Profile
-                                </button>
-                            ) : (
-                                <div>
-                                    <button
-                                        className="btn btn-light btn-sm me-2"
-                                        onClick={() => setIsEditing(false)}
-                                        disabled={isLoading}
-                                    >
-                                        <i className="bi bi-x me-1"></i>
-                                        Cancel
-                                    </button>
-                                    <button
-                                        className="btn btn-success btn-sm"
-                                        onClick={handleSaveProfile}
-                                        disabled={isLoading}
-                                    >
-                                        {isLoading ? (
-                                            <>
-                                                <span className="spinner-border spinner-border-sm me-1"></span>
-                                                Saving...
-                                            </>
-                                        ) : (
-                                            <>
-                                                <i className="bi bi-check me-1"></i>
-                                                Save Changes
-                                            </>
-                                        )}
-                                    </button>
-                                </div>
-                            )}
-                        </div>
-                        <div className="card-body">
-                            <form onSubmit={handleSaveProfile}>
-                                <div className="row">
-                                    <div className="col-md-6 mb-3">
-                                        <label className="form-label fw-semibold">Name</label>
-                                        <input
-                                            type="text"
-                                            name="name"
-                                            className="form-control"
-                                            value={candidateData.name || ""}
-                                            onChange={handleInputChange}
-                                            disabled={!isEditing}
-                                        />
-                                    </div>
-                                    <div className="col-md-6 mb-3">
-                                        <label className="form-label fw-semibold">Age</label>
-                                        <input
-                                            type="number"
-                                            name="age"
-                                            className="form-control"
-                                            value={candidateData.age || ""}
-                                            onChange={handleInputChange}
-                                            disabled={!isEditing}
-                                            min="18"
-                                            max="65"
-                                        />
-                                    </div>
-                                    <div className="col-md-6 mb-3">
-                                        <label className="form-label fw-semibold">Email</label>
-                                        <input
-                                            type="email"
-                                            className="form-control"
-                                            value={candidateData.email || ""}
-                                            disabled
-                                        />
-                                        <small className="text-muted">Email cannot be changed</small>
-                                    </div>
-                                    <div className="col-md-6 mb-3">
-                                        <label className="form-label fw-semibold">Mobile</label>
-                                        <input
-                                            type="text"
-                                            name="mobile"
-                                            className="form-control"
-                                            value={candidateData.mobile || ""}
-                                            onChange={handleInputChange}
-                                            disabled={!isEditing}
-                                        />
-                                    </div>
-                                    <div className="col-md-6 mb-3">
-                                        <label className="form-label fw-semibold">Qualification</label>
-                                        <input
-                                            type="text"
-                                            name="qualification"
-                                            className="form-control"
-                                            value={candidateData.qualification || ""}
-                                            onChange={handleInputChange}
-                                            disabled={!isEditing}
-                                        />
-                                    </div>
-                                    <div className="col-md-6 mb-3">
-                                        <label className="form-label fw-semibold">Location</label>
-                                        <input
-                                            type="text"
-                                            name="location"
-                                            className="form-control"
-                                            value={candidateData.location || ""}
-                                            onChange={handleInputChange}
-                                            disabled={!isEditing}
-                                        />
-                                    </div>
-                                    <div className="col-md-12 mb-3">
-                                        <label className="form-label fw-semibold">Occupation Status</label>
-                                        <select
-                                            name="occupationStatus"
-                                            className="form-select"
-                                            value={candidateData.occupationStatus || ""}
-                                            onChange={handleInputChange}
-                                            disabled={!isEditing}
-                                        >
-                                            <option value="">Select Status</option>
-                                            <option value="Available">Available</option>
-                                            <option value="Not Available">Not Available</option>
-                                        </select>
-                                    </div>
-
-                                    {/* File upload fields - only show when editing */}
-                                    {isEditing && (
-                                        <>
-                                            <div className="col-md-6 mb-3">
-                                                <label className="form-label fw-semibold">
-                                                    <i className="bi bi-file-earmark-text me-2"></i>
-                                                    Update Resume
-                                                </label>
-                                                <input
-                                                    type="file"
-                                                    name="resume"
-                                                    className="form-control"
-                                                    onChange={handleFileChange}
-                                                    accept=".pdf,.doc,.docx"
-                                                />
-                                                <small className="text-muted">Accepted formats: PDF, DOC, DOCX (Max 5MB)</small>
-                                            </div>
-                                            <div className="col-md-6 mb-3">
-                                                <label className="form-label fw-semibold">
-                                                    <i className="bi bi-file-earmark-image me-2"></i>
-                                                    Update ID Proof
-                                                </label>
-                                                <input
-                                                    type="file"
-                                                    name="idProof"
-                                                    className="form-control"
-                                                    onChange={handleFileChange}
-                                                    accept=".pdf,.jpg,.jpeg,.png"
-                                                />
-                                                <small className="text-muted">Accepted formats: PDF, JPG, PNG (Max 5MB)</small>
-                                            </div>
-                                        </>
-                                    )}
-                                </div>
-                            </form>
+        <div className="min-vh-100" style={{ backgroundColor: '#f8f9fa' }}>
+            <style jsx>{`
+                .info-card {
+                    background: white;
+                    border-radius: 12px;
+                    padding: 1.5rem;
+                    border: 1px solid #e9ecef;
+                    transition: all 0.3s ease;
+                }
+                
+                .info-card:hover {
+                    transform: translateY(-2px);
+                    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+                    border-color: #dee2e6;
+                }
+                
+                .update-card {
+                    background: white;
+                    border-radius: 15px;
+                    padding: 1.5rem;
+                    border: 2px solid #e9ecef;
+                    transition: all 0.3s ease;
+                }
+                
+                .update-card:hover {
+                    border-color: #667eea;
+                    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.1);
+                }
+                
+                .completion-card {
+                    background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+                    border-radius: 15px;
+                    padding: 2rem;
+                    border: 1px solid #dee2e6;
+                }
+                
+                .completion-item {
+                    padding: 1rem;
+                    border-radius: 10px;
+                    background: white;
+                    transition: all 0.3s ease;
+                }
+                
+                .completion-item:hover {
+                    transform: translateY(-3px);
+                    box-shadow: 0 6px 20px rgba(0,0,0,0.1);
+                }
+                
+                .icon-wrapper {
+                    width: 40px;
+                    height: 40px;
+                    border-radius: 50%;
+                    background: rgba(102, 126, 234, 0.1);
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    font-size: 1.2rem;
+                }
+                
+                .status-display .badge {
+                    font-size: 0.9rem;
+                    padding: 0.5rem 1rem;
+                    border-radius: 20px;
+                }
+                
+                .btn:hover {
+                    transform: translateY(-1px);
+                    box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+                }
+            `}</style>
+            <div className="container py-5">
+                {/* Header */}
+                <div className="row mb-4">
+                    <div className="col-12">
+                        <div className="d-flex justify-content-between align-items-center">
+                            <div>
+                                <h2 className="text-dark fw-bold mb-1">Candidate Profile</h2>
+                                <p className="text-muted mb-0">Manage your profile information</p>
+                            </div>
+                            <button
+                                className="btn btn-outline-danger"
+                                onClick={handleLogout}
+                            >
+                                <i className="bi bi-box-arrow-right me-2"></i>
+                                Logout
+                            </button>
                         </div>
                     </div>
                 </div>
 
-                {/* Profile Summary Card */}
-                <div className="col-lg-4">
-                    <div className="card shadow">
-                        <div className="card-header bg-info text-white">
-                            <h5 className="mb-0">
-                                <i className="bi bi-person-badge me-2"></i>
-                                Profile Summary
-                            </h5>
-                        </div>
-                        <div className="card-body">
-                            <div className="text-center mb-3">
-                                <div className="bg-primary rounded-circle d-inline-flex align-items-center justify-content-center"
-                                    style={{ width: '80px', height: '80px' }}>
-                                    <i className="bi bi-person-fill text-white" style={{ fontSize: '2rem' }}></i>
-                                </div>
-                                <h5 className="mt-2 mb-0">{candidateData.name || "Not Set"}</h5>
-                                <small className="text-muted">{candidateData.email || "No email"}</small>
-                            </div>
-
-                            <div className="border-top pt-3">
-                                <div className="d-flex justify-content-between mb-2">
-                                    <span className="text-muted">Status:</span>
-                                    <span className={`badge ${candidateData.occupationStatus === 'Available' ? 'bg-success' : 'bg-secondary'}`}>
-                                        {candidateData.occupationStatus || 'Not Set'}
-                                    </span>
-                                </div>
-                                <div className="d-flex justify-content-between mb-2">
-                                    <span className="text-muted">Age:</span>
-                                    <span>{candidateData.age || 'Not Set'}</span>
-                                </div>
-                                <div className="d-flex justify-content-between mb-2">
-                                    <span className="text-muted">Mobile:</span>
-                                    <span>{candidateData.mobile || 'Not Set'}</span>
-                                </div>
-                                <div className="d-flex justify-content-between mb-2">
-                                    <span className="text-muted">Location:</span>
-                                    <span>{candidateData.location || 'Not Set'}</span>
-                                </div>
-                                <div className="d-flex justify-content-between">
-                                    <span className="text-muted">Qualification:</span>
-                                    <span>{candidateData.qualification || 'Not Set'}</span>
-                                </div>
-                            </div>
-
-                            {/* File Status with Download Options */}
-                            <div className="border-top pt-3 mt-3">
-                                <h6 className="fw-semibold">
-                                    <i className="bi bi-files me-2"></i>
-                                    Documents Status
-                                </h6>
-
-                                {/* Resume Status */}
-                                <div className="d-flex justify-content-between align-items-center mb-2">
-                                    <span className="text-muted">Resume:</span>
-                                    <div>
-                                        {resumeInfo ? (
-                                            <div className="d-flex align-items-center gap-2">
-                                                <span className="badge bg-success">Uploaded</span>
-
-                                            </div>
-                                        ) : (
-                                            <span className="badge bg-warning">Pending</span>
-                                        )}
-                                    </div>
-                                </div>
-                                {resumeInfo && (
-                                    <small className="text-muted d-block mb-2">
-                                        <i className="bi bi-info-circle me-1"></i>
-                                        Size: {formatFileSize(resumeInfo.size)} | Type: {resumeInfo.type?.split('/')[1] || 'file'}
-                                    </small>
-                                )}
-
-                                {/* ID Proof Status */}
-                                <div className="d-flex justify-content-between align-items-center">
-                                    <span className="text-muted">ID Proof:</span>
-                                    <div>
-                                        {idProofInfo ? (
-                                            <div className="d-flex align-items-center gap-2">
-                                                <span className="badge bg-success">Uploaded</span>
-
-                                            </div>
-                                        ) : (
-                                            <span className="badge bg-warning">Pending</span>
-                                        )}
-                                    </div>
-                                </div>
-                                {idProofInfo && (
-                                    <small className="text-muted d-block">
-                                        <i className="bi bi-info-circle me-1"></i>
-                                        Size: {formatFileSize(idProofInfo.size)} | Type: {idProofInfo.type?.split('/')[1] || 'file'}
-                                    </small>
-                                )}
-                            </div>
-                        </div>
+                {/* Message Alert */}
+                {message && (
+                    <div className={`alert ${message.includes("success") ? "alert-success" : message.includes("selected") ? "alert-info" : "alert-danger"} alert-dismissible fade show`}>
+                        {message}
+                        <button
+                            type="button"
+                            className="btn-close"
+                            onClick={() => setMessage("")}
+                        ></button>
                     </div>
+                )}
 
-                    {/* Quick Actions Card */}
-                    <div className="card shadow mt-3">
-                        <div className="card-header bg-secondary text-white">
-                            <h6 className="mb-0">
-                                <i className="bi bi-lightning me-2"></i>
-                                Quick Actions
-                            </h6>
-                        </div>
-                        <div className="card-body">
-                            <div className="d-grid gap-2">
-                                <button
-                                    className="btn btn-outline-primary btn-sm"
-                                    onClick={() => setIsEditing(!isEditing)}
-                                    disabled={isLoading}
-                                >
-                                    <i className="bi bi-pencil me-1"></i>
-                                    {isEditing ? 'Cancel Edit' : 'Edit Profile'}
-                                </button>
-                                <button
-                                    className="btn btn-outline-info btn-sm"
-                                    onClick={() => window.location.reload()}
-                                    disabled={isLoading}
-                                >
-                                    <i className="bi bi-arrow-clockwise me-1"></i>
-                                    Refresh Data
-                                </button>
-                                <button
-                                    className="btn btn-outline-success btn-sm"
-                                    onClick={() => navigate("/candidate/register")}
-                                >
-                                    <i className="bi bi-person-plus me-1"></i>
-                                    Create New Account
-                                </button>
+                {/* Main Profile Card */}
+                <div className="row justify-content-center">
+                    <div className="col-lg-8">
+                        <div className="card shadow-lg border-0" style={{ borderRadius: '20px' }}>
+                            <div className="card-body p-0">
+                                {/* Header Section with Avatar */}
+                                <div className="bg-gradient text-white text-center p-4" style={{ 
+                                    background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)', 
+                                    borderRadius: '20px 20px 0 0' 
+                                }}>
+                                    <div className="position-relative d-inline-block mb-3">
+                                        <div className="bg-white rounded-circle d-flex align-items-center justify-content-center mx-auto shadow" 
+                                             style={{ width: '100px', height: '100px' }}>
+                                            <span className="text-primary fw-bold" style={{ fontSize: '2.5rem' }}>
+                                                {candidateData.name ? 
+                                                    candidateData.name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2) 
+                                                    : 'NA'
+                                                }
+                                            </span>
+                                        </div>
+                                        <div className="position-absolute bottom-0 end-0 bg-success rounded-circle" 
+                                             style={{ width: '25px', height: '25px' }}>
+                                            <i className="bi bi-check text-white" style={{ fontSize: '0.8rem', marginLeft: '6px', marginTop: '3px' }}></i>
+                                        </div>
+                                    </div>
+                                    <h3 className="fw-bold mb-1">{candidateData.name || "Not Set"}</h3>
+                                    <p className="mb-0 opacity-75">{candidateData.email || "No email"}</p>
+                                </div>
+
+                                {/* Profile Content */}
+                                <div className="p-5">
+                                    {/* Personal Information Grid */}
+                                    <div className="row g-4 mb-5">
+                                        <div className="col-md-6">
+                                            <div className="info-card h-100">
+                                                <div className="d-flex align-items-center mb-2">
+                                                    <div className="icon-wrapper me-3">
+                                                        <i className="bi bi-person text-primary"></i>
+                                                    </div>
+                                                    <div>
+                                                        <small className="text-muted">Full Name</small>
+                                                        <div className="fw-semibold">{candidateData.name || "Not Available"}</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        
+                                        <div className="col-md-6">
+                                            <div className="info-card h-100">
+                                                <div className="d-flex align-items-center mb-2">
+                                                    <div className="icon-wrapper me-3">
+                                                        <i className="bi bi-calendar text-primary"></i>
+                                                    </div>
+                                                    <div>
+                                                        <small className="text-muted">Age</small>
+                                                        <div className="fw-semibold">{candidateData.age || "Not Available"}</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        
+                                        <div className="col-md-6">
+                                            <div className="info-card h-100">
+                                                <div className="d-flex align-items-center mb-2">
+                                                    <div className="icon-wrapper me-3">
+                                                        <i className="bi bi-envelope text-primary"></i>
+                                                    </div>
+                                                    <div>
+                                                        <small className="text-muted">Email Address</small>
+                                                        <div className="fw-semibold">{candidateData.email || "Not Available"}</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        
+                                        <div className="col-md-6">
+                                            <div className="info-card h-100">
+                                                <div className="d-flex align-items-center mb-2">
+                                                    <div className="icon-wrapper me-3">
+                                                        <i className="bi bi-phone text-primary"></i>
+                                                    </div>
+                                                    <div>
+                                                        <small className="text-muted">Mobile Number</small>
+                                                        <div className="fw-semibold">{candidateData.mobile || "Not Available"}</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        
+                                        <div className="col-md-6">
+                                            <div className="info-card h-100">
+                                                <div className="d-flex align-items-center mb-2">
+                                                    <div className="icon-wrapper me-3">
+                                                        <i className="bi bi-mortarboard text-primary"></i>
+                                                    </div>
+                                                    <div>
+                                                        <small className="text-muted">Qualification</small>
+                                                        <div className="fw-semibold">{candidateData.qualification || "Not Available"}</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        
+                                        <div className="col-md-6">
+                                            <div className="info-card h-100">
+                                                <div className="d-flex align-items-center mb-2">
+                                                    <div className="icon-wrapper me-3">
+                                                        <i className="bi bi-geo-alt text-primary"></i>
+                                                    </div>
+                                                    <div>
+                                                        <small className="text-muted">Location</small>
+                                                        <div className="fw-semibold">{candidateData.location || "Not Available"}</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    {/* Work Status & Documents Section */}
+                                    <div className="row g-4">
+                                        {/* Work Status */}
+                                        <div className="col-12">
+                                            <div className="update-card">
+                                                <div className="d-flex align-items-center justify-content-between mb-3">
+                                                    <div className="d-flex align-items-center">
+                                                        <div className="icon-wrapper me-3">
+                                                            <i className="bi bi-briefcase text-success"></i>
+                                                        </div>
+                                                        <div>
+                                                            <h6 className="mb-0 fw-bold">Work Status</h6>
+                                                            <small className="text-muted">Your current availability</small>
+                                                        </div>
+                                                    </div>
+                                                    {!isEditing && (
+                                                        <button
+                                                            className="btn btn-outline-primary btn-sm"
+                                                            onClick={() => setIsEditing(true)}
+                                                        >
+                                                            <i className="bi bi-pencil me-1"></i>
+                                                            Update
+                                                        </button>
+                                                    )}
+                                                </div>
+                                                
+                                                {isEditing ? (
+                                                    <div className="d-flex gap-2 align-items-center">
+                                                        <select
+                                                            name="occupationStatus"
+                                                            className="form-select"
+                                                            value={candidateData.occupationStatus || ""}
+                                                            onChange={handleInputChange}
+                                                        >
+                                                            <option value="">Select Work Status</option>
+                                                            <option value="Available">Available for Work</option>
+                                                            <option value="Not Available">Not Available</option>
+                                                            <option value="Currently Employed">Currently Employed</option>
+                                                            <option value="Freelancing">Freelancing</option>
+                                                        </select>
+                                                        <button
+                                                            className="btn btn-success btn-sm"
+                                                            onClick={handleSaveProfile}
+                                                            disabled={isLoading}
+                                                        >
+                                                            {isLoading ? (
+                                                                <span className="spinner-border spinner-border-sm"></span>
+                                                            ) : (
+                                                                <i className="bi bi-check"></i>
+                                                            )}
+                                                        </button>
+                                                        <button
+                                                            className="btn btn-secondary btn-sm"
+                                                            onClick={() => setIsEditing(false)}
+                                                            disabled={isLoading}
+                                                        >
+                                                            <i className="bi bi-x"></i>
+                                                        </button>
+                                                    </div>
+                                                ) : (
+                                                    <div className="status-display">
+                                                        <span className={`badge ${candidateData.occupationStatus === 'Available' ? 'bg-success' : 
+                                                                       candidateData.occupationStatus === 'Currently Employed' ? 'bg-info' :
+                                                                       candidateData.occupationStatus === 'Freelancing' ? 'bg-warning' : 'bg-secondary'}`}>
+                                                            {candidateData.occupationStatus || "Status not set"}
+                                                        </span>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </div>
+
+                                        {/* Documents Section */}
+                                        <div className="col-md-6">
+                                            <div className="update-card h-100">
+                                                <div className="d-flex align-items-center justify-content-between mb-3">
+                                                    <div className="d-flex align-items-center">
+                                                        <div className="icon-wrapper me-3">
+                                                            <i className="bi bi-file-earmark-text text-info"></i>
+                                                        </div>
+                                                        <div>
+                                                            <h6 className="mb-0 fw-bold">Resume</h6>
+                                                            <small className="text-muted">Upload your CV</small>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                
+                                                {isEditing ? (
+                                                    <div>
+                                                        <input
+                                                            type="file"
+                                                            name="resume"
+                                                            className="form-control"
+                                                            onChange={handleFileChange}
+                                                            accept=".pdf,.doc,.docx"
+                                                        />
+                                                        <small className="text-muted">PDF, DOC, DOCX (Max 5MB)</small>
+                                                    </div>
+                                                ) : (
+                                                    <div>
+                                                        {resumeInfo ? (
+                                                            <div className="d-flex align-items-center justify-content-between">
+                                                                <div>
+                                                                    <span className="badge bg-success mb-1">
+                                                                        <i className="bi bi-check-circle me-1"></i>
+                                                                        Uploaded
+                                                                    </span>
+                                                                    <div>
+                                                                        <small className="text-muted">
+                                                                            {formatFileSize(resumeInfo.size)} • {resumeInfo.type?.split('/')[1] || 'file'}
+                                                                        </small>
+                                                                    </div>
+                                                                </div>
+                                                                <button
+                                                                    className="btn btn-outline-primary btn-sm"
+                                                                    onClick={() => handleDownloadFile(candidateData.resume, 'resume')}
+                                                                >
+                                                                    <i className="bi bi-download"></i>
+                                                                </button>
+                                                            </div>
+                                                        ) : (
+                                                            <div className="text-center py-3">
+                                                                <i className="bi bi-cloud-upload text-muted" style={{ fontSize: '2rem' }}></i>
+                                                                <div className="text-muted mt-2">No resume uploaded</div>
+                                                                <button
+                                                                    className="btn btn-outline-primary btn-sm mt-2"
+                                                                    onClick={() => setIsEditing(true)}
+                                                                >
+                                                                    Upload Resume
+                                                                </button>
+                                                            </div>
+                                                        )}
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </div>
+
+                                        <div className="col-md-6">
+                                            <div className="update-card h-100">
+                                                <div className="d-flex align-items-center justify-content-between mb-3">
+                                                    <div className="d-flex align-items-center">
+                                                        <div className="icon-wrapper me-3">
+                                                            <i className="bi bi-file-earmark-image text-warning"></i>
+                                                        </div>
+                                                        <div>
+                                                            <h6 className="mb-0 fw-bold">ID Proof</h6>
+                                                            <small className="text-muted">Identity verification</small>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                
+                                                {isEditing ? (
+                                                    <div>
+                                                        <input
+                                                            type="file"
+                                                            name="idProof"
+                                                            className="form-control"
+                                                            onChange={handleFileChange}
+                                                            accept=".pdf,.jpg,.jpeg,.png"
+                                                        />
+                                                        <small className="text-muted">PDF, JPG, PNG (Max 5MB)</small>
+                                                    </div>
+                                                ) : (
+                                                    <div>
+                                                        {idProofInfo ? (
+                                                            <div className="d-flex align-items-center justify-content-between">
+                                                                <div>
+                                                                    <span className="badge bg-success mb-1">
+                                                                        <i className="bi bi-check-circle me-1"></i>
+                                                                        Uploaded
+                                                                    </span>
+                                                                    <div>
+                                                                        <small className="text-muted">
+                                                                            {formatFileSize(idProofInfo.size)} • {idProofInfo.type?.split('/')[1] || 'file'}
+                                                                        </small>
+                                                                    </div>
+                                                                </div>
+                                                                <button
+                                                                    className="btn btn-outline-primary btn-sm"
+                                                                    onClick={() => handleDownloadFile(candidateData.idProof, 'id-proof')}
+                                                                >
+                                                                    <i className="bi bi-download"></i>
+                                                                </button>
+                                                            </div>
+                                                        ) : (
+                                                            <div className="text-center py-3">
+                                                                <i className="bi bi-cloud-upload text-muted" style={{ fontSize: '2rem' }}></i>
+                                                                <div className="text-muted mt-2">No ID proof uploaded</div>
+                                                                <button
+                                                                    className="btn btn-outline-primary btn-sm mt-2"
+                                                                    onClick={() => setIsEditing(true)}
+                                                                >
+                                                                    Upload ID Proof
+                                                                </button>
+                                                            </div>
+                                                        )}
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    {/* Profile Completion Stats */}
+                                    <div className="row mt-5">
+                                        <div className="col-12">
+                                            <div className="completion-card">
+                                                <h6 className="fw-bold mb-3 text-center">Profile Completion</h6>
+                                                <div className="row text-center g-3">
+                                                    <div className="col-4">
+                                                        <div className="completion-item">
+                                                            <i className="bi bi-person-check text-success" style={{ fontSize: '2rem' }}></i>
+                                                            <div className="mt-2">
+                                                                <strong>Personal Info</strong>
+                                                                <div className="text-success small">Complete</div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div className="col-4">
+                                                        <div className="completion-item">
+                                                            <i className={`bi bi-file-earmark-text ${resumeInfo ? 'text-success' : 'text-muted'}`} 
+                                                               style={{ fontSize: '2rem' }}></i>
+                                                            <div className="mt-2">
+                                                                <strong>Resume</strong>
+                                                                <div className={`small ${resumeInfo ? 'text-success' : 'text-muted'}`}>
+                                                                    {resumeInfo ? 'Uploaded' : 'Pending'}
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div className="col-4">
+                                                        <div className="completion-item">
+                                                            <i className={`bi bi-file-earmark-image ${idProofInfo ? 'text-success' : 'text-muted'}`} 
+                                                               style={{ fontSize: '2rem' }}></i>
+                                                            <div className="mt-2">
+                                                                <strong>ID Proof</strong>
+                                                                <div className={`small ${idProofInfo ? 'text-success' : 'text-muted'}`}>
+                                                                    {idProofInfo ? 'Uploaded' : 'Pending'}
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
- Add modern profile page with card-based layout and hover effects
- Fix routing typo from /cadidate/register to /candidate/register
- Add candidate name initials to profile avatar
- Remove cross-navigation between admin and candidate sides
- Implement inline editing for work status and document uploads
- Add clean navigation between login/register pages
- Remove 'Register New' button from profile for cleaner UX
- Add profile completion tracker with visual indicators